### PR TITLE
Removed 14.04 Ubuntu version from version check

### DIFF
--- a/roles/linux/version_check/tasks/main.yml
+++ b/roles/linux/version_check/tasks/main.yml
@@ -7,4 +7,4 @@
 - name: version check | Checking if distro version is supported by this playbook
   fail:
     msg: "Distribution version {{ ansible_distribution_version }} not supported by this playbook"
-  when: ansible_distribution_version != '16.04' and ansible_distribution_version != '14.04'
+  when: ansible_distribution_version != '16.04'


### PR DESCRIPTION
This change is made because 14.04 is not supported

Fixes #1 